### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,6 +8,7 @@
   "depends" : [ ],
   "description" : "A Perl 6 bindings for libmecab ( http://taku910.github.io/mecab/ )",
   "name" : "MeCab",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "MeCab" : "lib/MeCab.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license